### PR TITLE
Fix issue with older curl versions

### DIFF
--- a/src/GoogleCloudTracer/AuthProvider.php
+++ b/src/GoogleCloudTracer/AuthProvider.php
@@ -105,7 +105,7 @@ class AuthProvider implements AuthProviderInterface
             'curl',
             '--request',
             'POST',
-            '--data-raw',
+            '--data',
             $postData,
             '--retry',
             2,

--- a/src/GoogleCloudTracer/Recorder.php
+++ b/src/GoogleCloudTracer/Recorder.php
@@ -110,7 +110,7 @@ class Recorder implements RecorderInterface
             '--retry',
             2,
             '--silent',
-            '--data-raw',
+            '--data',
             ProcessUtils::escapeArgument($json),
             ProcessUtils::escapeArgument($this->projectUrl),
         ];


### PR DESCRIPTION
Use `data` not `data-raw` (introduced in curl [7.43.0](https://github.com/jsonn/pkgsrc/commit/15a31b8517385463d21e69a57ee59bc9fd8a352e)) makes ubuntu 14 work