### PR TITLE
GoogleCloudTracer - Support UUID and Basictracer-go tracerId

### DIFF
--- a/src/GoogleCloudTracer/Recorder.php
+++ b/src/GoogleCloudTracer/Recorder.php
@@ -79,11 +79,21 @@ class Recorder implements RecorderInterface
             $traceSpan['labels'] = $labels;
         }
 
+        // Resolve the traceId for google cloud
+        // Related to https://github.com/hellofresh/gcloud-opentracing/blob/master/recorder.go#L98
+        $traceId = $context->getTraceId();
+        if (strlen($traceId) === 36) {
+            $traceId = str_replace('-', '', $traceId);
+        }
+        if (strlen($traceId) === 16) {
+            $traceId = $traceId . $traceId;
+        }
+
         // https://cloud.google.com/trace/docs/reference/v1/rest/v1/projects/patchTraces
         $data = json_encode([ 'traces' => [
             [
                 'projectId' => $this->projectId,
-                'traceId' => $context->getTraceId(),
+                'traceId' => $traceId,
                 'spans' => $traceSpan,
             ],
         ] ]);


### PR DESCRIPTION
This PR fixes a issue where the tracerId coming from for example the basictracer-go are not supported.
