### PR TITLE
Make symfony/process an optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,15 @@
         "lcobucci/jwt": "^3.2",
         "doctrine/cache": "^1.6",
         "ramsey/uuid": "^3.6",
-        "moontoast/math": "^1.1",
-        "symfony/process": "^3.0"
+        "moontoast/math": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
-        "friendsofphp/php-cs-fixer": "^2.0"
+        "friendsofphp/php-cs-fixer": "^2.0",
+        "symfony/process": "^3.0"
+    },
+    "suggest": {
+        "symfony/process": "Needed for the GoogleCloudTracer recorder"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Moves `symfony/process` to dev packages, and suggests installing it if you want to use GoogleCloudTracer recorder.