### PR TITLE
LOGIST-659 - Extract formatter

### DIFF
--- a/src/GoogleCloudTracer/Formatter/GoogleCloudFormatter.php
+++ b/src/GoogleCloudTracer/Formatter/GoogleCloudFormatter.php
@@ -1,0 +1,179 @@
+<?php declare(strict_types=1);
+
+namespace HelloFresh\GoogleCloudTracer\Formatter;
+
+use HelloFresh\BasicTracer\Span;
+use HelloFresh\BasicTracer\SpanContext;
+use HelloFresh\BasicTracer\Tags;
+use HelloFresh\OpenTracing\SpanInterface;
+use HelloFresh\OpenTracing\SpanKind;
+
+class GoogleCloudFormatter implements TraceFormatterInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function formatTrace(string $projectId, string $traceId, array $spans)
+    {
+        $spanArrays = array_map(function ($span) {
+            return is_array($span) ? $this->assertSpanArray($span) : $this->formatSpan($span);
+        }, $spans);
+
+        return json_encode([
+            'traces' => [
+                [
+                    'projectId' => $projectId,
+                    'traceId' => $traceId,
+                    'spans' => $spanArrays,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function formatSpan(SpanInterface $span)
+    {
+        if (!$span instanceof Span) {
+            throw new \Exception('Instance of Span is necessary proper formatting');
+        }
+
+        $context = $span->context();
+        if (!$context instanceof SpanContext) {
+            throw new \Exception('Instance of SpanContext is necessary proper formatting');
+        }
+
+        // https://cloud.google.com/trace/docs/reference/v1/rest/v1/projects.traces#TraceSpan
+        $traceSpan = [
+            'spanId' => (string) $context->getSpanId(),
+            'kind' => $this->getSpanKind($span),
+            'name' => $span->getOperationName(),
+            'startTime' => $this->formatTimestamp($span->getStartTimestamp()),
+            'endTime' => $this->formatTimestamp($span->getEndTimestamp()),
+        ];
+
+        if ($span->getParentSpanId() !== null) {
+            $traceSpan['parentSpanId'] = (string) $span->getParentSpanId();
+        }
+
+        $labels = $this->extractLabels($span);
+        if (!empty($labels)) {
+            $traceSpan['labels'] = $labels;
+        }
+
+        return $traceSpan;
+    }
+
+    /**
+     * @param float $timestamp
+     *
+     * @return string
+     */
+    private function formatTimestamp(float $timestamp) : string
+    {
+        return \DateTime::createFromFormat('U.u', (string) $timestamp)->format('Y-m-d\TH:i:s.uP');
+    }
+
+    /**
+     * @see https://github.com/opentracing/specification/blob/master/semantic_conventions.md#rpcs
+     *
+     * @param Span $span
+     *
+     * @return string
+     */
+    private function getSpanKind(Span $span) : string
+    {
+        $tags = $span->getTags();
+        $kind = $tags[Tags::SPAN_KIND] ?? null;
+
+        switch ($kind) {
+            case 'server':
+                return SpanKind::RPC_SERVER;
+            case 'client':
+                return SpanKind::RPC_CLIENT;
+            default:
+                return SpanKind::UNSPECIFIED;
+        }
+    }
+
+    /**
+     * Extract information from the span into gcloud trace labels
+     *
+     * @param Span $span
+     *
+     * @return array
+     */
+    private function extractLabels(Span $span) : array
+    {
+        $labels = [];
+
+        $this->appendTags($labels, $span);
+        $this->appendLogs($labels, $span);
+
+        return $labels;
+    }
+
+    /**
+     * Append opentracing tags into gcloud trace labels
+     *
+     * @param Span $span
+     * @param array $labels
+     */
+    private function appendTags(array &$labels, Span $span)
+    {
+        // Rewrite opentracinglabels into those gcloud-native labels
+        // https://github.com/GoogleCloudPlatform/google-cloud-go/blob/master/trace/trace.go#L178
+        $labelMap = [
+            Tags::PEER_HOSTNAME => 'trace.cloud.google.com/http/host',
+            Tags::HTTP_METHOD => 'trace.cloud.google.com/http/method',
+            Tags::HTTP_STATUS_CODE => 'trace.cloud.google.com/http/status_code',
+            Tags::HTTP_URL => 'trace.cloud.google.com/http/url',
+        ];
+
+        foreach ($span->getTags() as $key => $value) {
+            if (isset($labelMap[$key])) {
+                $key = $labelMap[$key];
+            }
+
+            $labels[$key] = (string) $value;
+        }
+    }
+
+    /**
+     * Append opentracing logs into gcloud trace labels
+     *
+     * @param array $labels
+     * @param Span $span
+     */
+    private function appendLogs(array &$labels, Span $span)
+    {
+        foreach ($span->getLogs() as $key => $values) {
+            foreach ($values as $i => $info) {
+                if (empty($info[1])) {
+                    $value = $info[0];
+                } else {
+                    $value = sprintf('%s %d', $info[0], $info[1]);
+                }
+
+                $labels[sprintf('log_%s_%d', $key, $i)] = (string) $value;
+            }
+        }
+    }
+
+    /**
+     * @param array $span
+     *
+     * @return array
+     */
+    private function assertSpanArray(array $span) : array
+    {
+        $requiredKeys = ['spanId', 'kind', 'name', 'startTime', 'endTime'];
+        $diff = array_diff($requiredKeys, array_keys($span));
+        if ($diff) {
+            throw new \Exception(sprintf('Missing required attributes %s', implode(', ', $diff)));
+        }
+
+        return $span;
+    }
+}

--- a/src/GoogleCloudTracer/Formatter/TraceFormatterInterface.php
+++ b/src/GoogleCloudTracer/Formatter/TraceFormatterInterface.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace HelloFresh\GoogleCloudTracer\Formatter;
+
+use HelloFresh\OpenTracing\SpanInterface;
+
+interface TraceFormatterInterface
+{
+    /**
+     * Formats a trace to an arbitrary representation
+     *
+     * @param string $projectId
+     * @param string $traceId
+     * @param SpanInterface[]|array $spans
+     *
+     * @return mixed
+     */
+    public function formatTrace(string $projectId, string $traceId, array $spans);
+
+    /**
+     * Formats a span to an arbitrary representation
+     *
+     * @param SpanInterface $span
+     *
+     * @return mixed
+     */
+    public function formatSpan(SpanInterface $span);
+}

--- a/src/GoogleCloudTracer/Recorder.php
+++ b/src/GoogleCloudTracer/Recorder.php
@@ -5,7 +5,8 @@ namespace HelloFresh\GoogleCloudTracer;
 use HelloFresh\BasicTracer\RecorderInterface;
 use HelloFresh\BasicTracer\Span;
 use HelloFresh\BasicTracer\SpanContext;
-use HelloFresh\BasicTracer\Tags;
+use HelloFresh\GoogleCloudTracer\Formatter\GoogleCloudFormatter;
+use HelloFresh\GoogleCloudTracer\Formatter\TraceFormatterInterface;
 use HelloFresh\OpenTracing\SpanInterface;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessUtils;
@@ -34,13 +35,28 @@ class Recorder implements RecorderInterface
     private $logFile;
 
     /**
+     * @var TraceFormatterInterface
+     */
+    private $formatter;
+
+    /**
      * @param AuthProviderInterface $authHandler
      * @param string $projectId
+     * @param TraceFormatterInterface|null $formatter
      */
-    public function __construct(AuthProviderInterface $authHandler, string $projectId)
-    {
+    public function __construct(
+        AuthProviderInterface $authHandler,
+        string $projectId,
+        TraceFormatterInterface $formatter = null
+    ) {
+        if ($formatter === null) {
+            $formatter = new GoogleCloudFormatter();
+        }
+
         $this->authHandler = $authHandler;
         $this->projectId = $projectId;
+        $this->formatter = $formatter;
+
         $this->projectUrl = sprintf(
             'https://cloudtrace.googleapis.com/v1/projects/%s/traces',
             urlencode($this->projectId)
@@ -63,22 +79,6 @@ class Recorder implements RecorderInterface
             return;
         }
 
-        // https://cloud.google.com/trace/docs/reference/v1/rest/v1/projects.traces#TraceSpan
-        $traceSpan = [
-            'spanId' => (string) $context->getSpanId(),
-            'kind' => $this->getSpanKind($span),
-            'name' => $span->getOperationName(),
-            'startTime' => $this->formatTimestamp($span->getStartTimestamp()),
-            'endTime' => $this->formatTimestamp($span->getEndTimestamp()),
-        ];
-        if ($span->getParentSpanId() !== null) {
-            $traceSpan['parentSpanId'] = (string) $span->getParentSpanId();
-        }
-        $labels = $this->extractLabels($span);
-        if (!empty($labels)) {
-            $traceSpan['labels'] = $labels;
-        }
-
         // Resolve the traceId for google cloud
         // Related to https://github.com/hellofresh/gcloud-opentracing/blob/master/recorder.go#L98
         $traceId = $context->getTraceId();
@@ -89,14 +89,7 @@ class Recorder implements RecorderInterface
             $traceId = $traceId . $traceId;
         }
 
-        // https://cloud.google.com/trace/docs/reference/v1/rest/v1/projects/patchTraces
-        $data = json_encode([ 'traces' => [
-            [
-                'projectId' => $this->projectId,
-                'traceId' => $traceId,
-                'spans' => $traceSpan,
-            ],
-        ] ]);
+        $data = $this->formatter->formatTrace($this->projectId, $traceId, [$span]);
 
         // Send the request
         $process = $this->createRequestProcess($data);
@@ -143,98 +136,5 @@ class Recorder implements RecorderInterface
         $process->disableOutput();
 
         return $process;
-    }
-
-    /**
-     * @param float $timestamp
-     * @return string
-     */
-    private function formatTimestamp(float $timestamp) : string
-    {
-        return \DateTime::createFromFormat('U.u', (string) $timestamp)->format('Y-m-d\TH:i:s.uP');
-    }
-
-    /**
-     * @see https://github.com/opentracing/specification/blob/master/semantic_conventions.md#rpcs
-     *
-     * @param Span $span
-     * @return string
-     */
-    private function getSpanKind(Span $span) : string
-    {
-        $tags = $span->getTags();
-        $kind = $tags[Tags::SPAN_KIND] ?? null;
-
-        switch ($kind) {
-            case 'server':
-                return 'RPC_SERVER';
-            case 'client':
-                return 'RPC_CLIENT';
-            default:
-                return 'SPAN_KIND_UNSPECIFIED';
-        }
-    }
-
-    /**
-     * Extract information from the span into gcloud trace labels
-     *
-     * @param Span $span
-     * @return array
-     */
-    private function extractLabels(Span $span) : array
-    {
-        $labels = [];
-
-        $this->appendTags($labels, $span);
-        $this->appendLogs($labels, $span);
-
-        return $labels;
-    }
-
-    /**
-     * Append opentracing tags into gcloud trace labels
-     *
-     * @param Span $span
-     * @param array $labels
-     */
-    private function appendTags(array &$labels, Span $span)
-    {
-        // Rewrite opentracinglabels into those gcloud-native labels
-        // https://github.com/GoogleCloudPlatform/google-cloud-go/blob/master/trace/trace.go#L178
-        $labelMap = [
-            Tags::PEER_HOSTNAME => 'trace.cloud.google.com/http/host',
-            Tags::HTTP_METHOD => 'trace.cloud.google.com/http/method',
-            Tags::HTTP_STATUS_CODE => 'trace.cloud.google.com/http/status_code',
-            Tags::HTTP_URL => 'trace.cloud.google.com/http/url',
-        ];
-
-        foreach ($span->getTags() as $key => $value) {
-            if (isset($labelMap[$key])) {
-                $key = $labelMap[$key];
-            }
-
-            $labels[$key] = (string) $value;
-        }
-    }
-
-    /**
-     * Append opentracing logs into gcloud trace labels
-     *
-     * @param array $labels
-     * @param Span $span
-     */
-    private function appendLogs(array &$labels, Span $span)
-    {
-        foreach ($span->getLogs() as $key => $values) {
-            foreach ($values as $i => $info) {
-                if (empty($info[1])) {
-                    $value = $info[0];
-                } else {
-                    $value = sprintf('%s %d', $info[0], $info[1]);
-                }
-
-                $labels[sprintf('log_%s_%d', $key, $i)] = (string) $value;
-            }
-        }
     }
 }

--- a/src/OpenTracing/SpanKind.php
+++ b/src/OpenTracing/SpanKind.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace HelloFresh\OpenTracing;
+
+class SpanKind
+{
+    const RPC_SERVER = 'RPC_SERVER';
+    const RPC_CLIENT = 'RPC_CLIENT';
+    const UNSPECIFIED = 'SPAN_KIND_UNSPECIFIED';
+}

--- a/tests/GoogleCloudTracer/Formatter/GoogleCloudFormatterTest.php
+++ b/tests/GoogleCloudTracer/Formatter/GoogleCloudFormatterTest.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+namespace Tests\HelloFresh\GoogleCloudTracer\Formatter;
+
+use HelloFresh\BasicTracer\NoopRecorder;
+use HelloFresh\BasicTracer\Span;
+use HelloFresh\BasicTracer\SpanContext;
+use HelloFresh\GoogleCloudTracer\Formatter\GoogleCloudFormatter;
+use HelloFresh\OpenTracing\SpanKind;
+use PHPUnit\Framework\TestCase;
+
+class GoogleCloudFormatterTest extends TestCase
+{
+    /**
+     * @var GoogleCloudFormatter
+     */
+    private $formatter;
+
+    public function setUp()
+    {
+        $this->formatter = new GoogleCloudFormatter();
+    }
+
+    /**
+     * @test
+     */
+    public function checkTraceIsProperlyFormatted()
+    {
+        $recorder = new NoopRecorder();
+        $traceId = '11aa43be4634f4da';
+        $projectId = 'project-id';
+        $spanContext = new SpanContext($traceId, 1, false);
+        $span = new Span($recorder, microtime(true), 'trace-properly-formatted', $spanContext);
+        $span->finish();
+
+        $expectedData = [
+            'traces' => [
+                [
+                    'projectId' => $projectId,
+                    'traceId' => $traceId,
+                    'spans' => [
+                        [
+                            'spanId' => '1',
+                            'kind' => SpanKind::UNSPECIFIED,
+                            'name' => 'trace-properly-formatted'
+                        ]
+                    ],
+                ],
+            ],
+        ];
+
+        $data = json_decode($this->formatter->formatTrace($projectId, $traceId, [$span]), true);
+        $this->assertArrayHasKey('startTime', $data['traces'][0]['spans'][0]);
+        $this->assertArrayHasKey('endTime', $data['traces'][0]['spans'][0]);
+        unset($data['traces'][0]['spans'][0]['startTime']);
+        unset($data['traces'][0]['spans'][0]['endTime']);
+        $this->assertSame($expectedData, $data);
+    }
+
+    /**
+     * @test
+     */
+    public function checkTraceIsProperlyFormattedWithSpanArray()
+    {
+        $span = [
+            'spanId' => '1',
+            'kind' => SpanKind::UNSPECIFIED,
+            'name' => 'span-properly-formatted',
+            'startTime' => '2017-05-18T11:57:10.096800+00:00',
+            'endTime' => '2017-05-18T11:57:10.096800+00:00',
+        ];
+        $traceId = '11aa43be4634f4da';
+        $projectId = 'project-id';
+
+        $expectedData = [
+            'traces' => [
+                [
+                    'projectId' => $projectId,
+                    'traceId' => $traceId,
+                    'spans' => [
+                        $span,
+                    ],
+                ],
+            ],
+        ];
+
+        $data = json_decode($this->formatter->formatTrace($projectId, $traceId, [$span]), true);
+        $this->assertSame($expectedData, $data);
+    }
+
+    /**
+     * @test
+     */
+    public function checkTraceIsNotCorrectlyFormattedWithWrongSpanArray()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp('/Missing required attributes/');
+
+        $span = [
+            'spanId' => '1',
+            'kind' => SpanKind::UNSPECIFIED,
+            'name' => 'span-properly-formatted',
+        ];
+        $traceId = '11aa43be4634f4da';
+        $projectId = 'project-id';
+
+        $this->formatter->formatTrace($projectId, $traceId, [$span]);
+    }
+
+    /**
+     * @test
+     */
+    public function checkSpanIsCorrectlyFormatted()
+    {
+        $recorder = new NoopRecorder();
+        $traceId = '11aa43be4634f4da';
+        $spanContext = new SpanContext($traceId, 1, false);
+        $span = new Span($recorder, microtime(true), 'span-properly-formatted', $spanContext);
+        $span->finish();
+
+        $expectedData = [
+            'spanId' => '1',
+            'kind' => SpanKind::UNSPECIFIED,
+            'name' => 'span-properly-formatted',
+        ];
+        $data = $this->formatter->formatSpan($span);
+        $this->assertArrayHasKey('startTime', $data);
+        $this->assertArrayHasKey('endTime', $data);
+        unset($data['startTime']);
+        unset($data['endTime']);
+
+        $this->assertSame($expectedData, $data);
+    }
+}


### PR DESCRIPTION
This PR adds `GoogleCloudFormatter` which is used to format a Trace to be compatible with the Google Cloud `PATCH /traces` endpoint 