### PR TITLE
Use string for the textmap/httpmap inject

### DIFF
--- a/src/BasicTracer/Propagation/TextMapPropagator.php
+++ b/src/BasicTracer/Propagation/TextMapPropagator.php
@@ -86,7 +86,7 @@ class TextMapPropagator implements ExtractorInterface, InjectorInterface
 
         $carrier[self::FIELD_TRACE_ID] = $spanContext->getTraceId();
         $carrier[self::FIELD_SPAN_ID] = $spanContext->getSpanId();
-        $carrier[self::FIELD_SAMPLED] = $spanContext->isSampled();
+        $carrier[self::FIELD_SAMPLED] = $spanContext->isSampled() ? "true" : "false";
 
         foreach ($spanContext->getBaggageItems() as $key => $value) {
             $carrier[self::PREFIX_BAGGAGE . $key] = $value;


### PR DESCRIPTION
Use string for the textmap/httpmap this fixes a issue were some http clients ignore headers set to `false`

This will fix https://graylog-scm000.tools.hellofresh.io/messages/graylog_73/360d63e0-8e29-11e7-8dad-067155f3af80