### PR TITLE
Remove dependency on ramsey/uuid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "OpenTracing API for PHP",
     "type": "library",
     "require": {
+        "php": ">=7.0",
         "lcobucci/jwt": "^3.2",
         "doctrine/cache": "^1.6",
-        "ramsey/uuid": "^3.6",
         "moontoast/math": "^1.1"
     },
     "require-dev": {

--- a/src/BasicTracer/BasicTracer.php
+++ b/src/BasicTracer/BasicTracer.php
@@ -11,7 +11,7 @@ use HelloFresh\OpenTracing\SpanInterface;
 use HelloFresh\OpenTracing\SpanReference;
 use HelloFresh\OpenTracing\TracerInterface;
 use Moontoast\Math\BigNumber;
-use Ramsey\Uuid\Uuid;
+use function random_bytes;
 
 class BasicTracer implements TracerInterface
 {
@@ -93,7 +93,7 @@ class BasicTracer implements TracerInterface
             }
         }
         if ($context === null) {
-            $traceId = Uuid::uuid4()->getMostSignificantBitsHex();
+            $traceId = $this->generateTraceId();
             $context = new SpanContext(
                 $traceId,
                 $spanId,
@@ -155,5 +155,10 @@ class BasicTracer implements TracerInterface
         $this->extractors[$format] = $extractor;
 
         return $this;
+    }
+
+    private function generateTraceId() : string
+    {
+        return bin2hex(random_bytes(8));
     }
 }


### PR DESCRIPTION
The goal is really to remove dependency on `paragonie/random_compat` which comes loaded with crap we don't care about in PHP 7+. Also it's using the dreaded Mcrypt extension.

BTW, I ran the tests against this branch and master and I get this:

```
1) Tests\HelloFresh\BasicTracer\Propagation\TextMapPropagatorTest::itInjectsContextIntoAnArray
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'ot-tracer-traceid' => 'test'
     'ot-tracer-spanid' => 324
-    'ot-tracer-sampled' => true
+    'ot-tracer-sampled' => 'true'

/Volumes/hellofresh/repositories/opentracing-php/tests/BasicTracer/Propagation/TextMapPropagatorTest.php:124

2) Tests\HelloFresh\BasicTracer\Propagation\TextMapPropagatorTest::itInjectsContextIntoAnArrayObject
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'ot-tracer-traceid' => 'test'
     'ot-tracer-spanid' => 324
-    'ot-tracer-sampled' => true
+    'ot-tracer-sampled' => 'true'

/Volumes/hellofresh/repositories/opentracing-php/tests/BasicTracer/Propagation/TextMapPropagatorTest.php:158
```